### PR TITLE
Add Hindi translation with basic i18n support

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,13 @@
       <div class="hero__top">
         <a class="brand" href="#">
           <span class="brand__logo" aria-hidden="true">🎮</span>
-          <span class="brand__text">Games Hub</span>
+          <span class="brand__text" data-i18n="brand.name"></span>
         </a>
         <div class="hero__actions">
-          <button id="theme-toggle" class="btn-icon" type="button" aria-label="Toggle theme">
+          <button id="theme-toggle" class="btn-icon" type="button" data-i18n-aria-label="aria.toggleTheme">
             <span class="theme-icon">☀️</span>
           </button>
-          <a class="btn-icon" id="github-link" href="https://github.com/sausi-7/games" target="_blank" rel="noopener" aria-label="View source on GitHub">
+          <a class="btn-icon" id="github-link" href="https://github.com/sausi-7/games" target="_blank" rel="noopener" data-i18n-aria-label="aria.viewSourceGithub">
             <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.69 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.96 10.96 0 0 1 5.74 0c2.18-1.49 3.14-1.18 3.14-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.14v3.17c0 .31.21.68.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5Z"/></svg>
             <span id="star-count" class="star-count" hidden>★ <em>—</em></span>
           </a>
@@ -34,19 +34,16 @@
       </div>
 
       <h1 class="hero__title">
-        <span class="grad">140+ playable games.</span>
-        <br />One repo. Zero installs.
+        <span class="grad" data-i18n="hero.titleLine1"></span>
+        <br /><span data-i18n="hero.titleLine2"></span>
       </h1>
-      <p class="hero__sub">
-        A growing collection of browser-built HTML5 games — built with Phaser, Three.js, and vanilla JS.
-        Click any card to play instantly.
-      </p>
+      <p class="hero__sub" data-i18n="hero.subtitle"></p>
 
       <div class="hero__cta">
         <button class="btn-primary" id="random-game" type="button">
-          <span>🎲</span> Play random
+          <span>🎲</span> <span data-i18n="cta.playRandom"></span>
         </button>
-        <a class="btn-ghost" href="#games">Browse all</a>
+        <a class="btn-ghost" href="#games" data-i18n="cta.browseAll"></a>
       </div>
 
       <div class="stats" id="stats" aria-hidden="true">
@@ -56,15 +53,15 @@
   </header>
 
   <main>
-    <section class="controls" aria-label="Filter games">
+    <section class="controls" data-i18n-aria-label="aria.filterGames">
       <div class="controls__inner">
         <label class="search">
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" d="m20 20-4.35-4.35M11 18a7 7 0 1 1 0-14 7 7 0 0 1 0 14Z"/></svg>
-          <input type="search" id="search-input" placeholder="Search games — name, tag, category…" autocomplete="off" />
+          <input type="search" id="search-input" data-i18n-placeholder="search.placeholder" autocomplete="off" />
           <kbd class="search__kbd">/</kbd>
         </label>
 
-        <nav class="filters" id="filters" aria-label="Categories">
+        <nav class="filters" id="filters" data-i18n-aria-label="aria.categories">
           <!-- filled by JS -->
         </nav>
       </div>
@@ -74,7 +71,7 @@
       <div class="games__inner">
         <div class="games__grid" id="grid"></div>
         <p class="games__empty" id="empty" hidden>
-          No games match this search. <button class="link" id="clear-filters" type="button">Clear filters</button>
+          <span data-i18n="empty.noMatches"></span> <button class="link" id="clear-filters" type="button" data-i18n="empty.clearFilters"></button>
         </p>
       </div>
     </section>
@@ -83,12 +80,19 @@
   <footer class="footer">
     <div class="footer__inner">
       <p>
-        Built by <a href="https://github.com/sausi-7" target="_blank" rel="noopener">Saurabh Singh</a>
-        · <a href="https://github.com/sausi-7/games" target="_blank" rel="noopener">Source</a>
-        · <a href="https://github.com/sausi-7/games/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contribute</a>
-        · MIT licensed
+        <span data-i18n="footer.builtBy"></span> <a href="https://github.com/sausi-7" target="_blank" rel="noopener">Saurabh Singh</a>
+        · <a href="https://github.com/sausi-7/games" target="_blank" rel="noopener" data-i18n="footer.source"></a>
+        · <a href="https://github.com/sausi-7/games/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener" data-i18n="footer.contribute"></a>
+        · <span data-i18n="footer.licensed"></span>
       </p>
-      <p class="footer__hint">Press <kbd>/</kbd> to search · <kbd>Esc</kbd> to close · <kbd>R</kbd> for random</p>
+      <p class="footer__hint">
+        <label for="language-select" data-i18n="footer.language"></label>
+        <select id="language-select">
+          <option value="en" data-i18n="language.english"></option>
+          <option value="hi" data-i18n="language.hindi"></option>
+        </select>
+      </p>
+      <p class="footer__hint"><span data-i18n="footer.press"></span> <kbd>/</kbd> <span data-i18n="footer.toSearch"></span> · <kbd>Esc</kbd> <span data-i18n="footer.toClose"></span> · <kbd>R</kbd> <span data-i18n="footer.forRandom"></span></p>
     </div>
   </footer>
 
@@ -99,17 +103,17 @@
       <header class="modal__bar">
         <div class="modal__meta">
           <span class="modal__chip" id="modal-chip"></span>
-          <h2 id="modal-title" class="modal__title">—</h2>
+          <h2 id="modal-title" class="modal__title" data-i18n="modal.defaultTitle"></h2>
         </div>
         <div class="modal__tools">
-          <button class="btn-icon" id="modal-fullscreen" type="button" aria-label="Toggle fullscreen" title="Fullscreen">⛶</button>
-          <button class="btn-icon" id="modal-reload" type="button" aria-label="Restart game" title="Restart">↻</button>
-          <a class="btn-icon" id="modal-open" target="_blank" rel="noopener" aria-label="Open in new tab" title="Open in new tab">↗</a>
-          <button class="btn-icon btn-icon--danger" id="modal-close" type="button" aria-label="Close" data-close title="Close">✕</button>
+          <button class="btn-icon" id="modal-fullscreen" type="button" data-i18n-aria-label="aria.toggleFullscreen" data-i18n-title="title.fullscreen">⛶</button>
+          <button class="btn-icon" id="modal-reload" type="button" data-i18n-aria-label="aria.restartGame" data-i18n-title="title.restart">↻</button>
+          <a class="btn-icon" id="modal-open" target="_blank" rel="noopener" data-i18n-aria-label="aria.openInNewTab" data-i18n-title="title.openInNewTab">↗</a>
+          <button class="btn-icon btn-icon--danger" id="modal-close" type="button" data-i18n-aria-label="aria.close" data-close data-i18n-title="title.close">✕</button>
         </div>
       </header>
       <div class="modal__frame-wrap">
-        <iframe id="modal-frame" class="modal__frame" title="Game" allow="autoplay; fullscreen; gamepad" sandbox="allow-scripts allow-same-origin allow-pointer-lock allow-modals allow-popups allow-forms"></iframe>
+        <iframe id="modal-frame" class="modal__frame" data-i18n-title="title.game" allow="autoplay; fullscreen; gamepad" sandbox="allow-scripts allow-same-origin allow-pointer-lock allow-modals allow-popups allow-forms"></iframe>
       </div>
     </div>
   </div>

--- a/site/app.js
+++ b/site/app.js
@@ -6,6 +6,96 @@
    ========================================================= */
 
 const GH_REPO = "sausi-7/games";
+const DEFAULT_LOCALE = "en";
+const LOCALE_STORAGE_KEY = "language";
+const I18N = {
+  en: {
+    "brand.name": "Games Hub",
+    "hero.titleLine1": "140+ playable games.",
+    "hero.titleLine2": "One repo. Zero installs.",
+    "hero.subtitle": "A growing collection of browser-built HTML5 games — built with Phaser, Three.js, and vanilla JS. Click any card to play instantly.",
+    "cta.playRandom": "Play random",
+    "cta.browseAll": "Browse all",
+    "search.placeholder": "Search games — name, tag, category…",
+    "empty.noMatches": "No games match this search.",
+    "empty.clearFilters": "Clear filters",
+    "footer.builtBy": "Built by",
+    "footer.source": "Source",
+    "footer.contribute": "Contribute",
+    "footer.licensed": "MIT licensed",
+    "footer.language": "Language:",
+    "footer.press": "Press",
+    "footer.toSearch": "to search",
+    "footer.toClose": "to close",
+    "footer.forRandom": "for random",
+    "language.english": "English",
+    "language.hindi": "Hindi",
+    "modal.defaultTitle": "—",
+    "aria.toggleTheme": "Toggle theme",
+    "aria.viewSourceGithub": "View source on GitHub",
+    "aria.filterGames": "Filter games",
+    "aria.categories": "Categories",
+    "aria.toggleFullscreen": "Toggle fullscreen",
+    "aria.restartGame": "Restart game",
+    "aria.openInNewTab": "Open in new tab",
+    "aria.close": "Close",
+    "title.fullscreen": "Fullscreen",
+    "title.restart": "Restart",
+    "title.openInNewTab": "Open in new tab",
+    "title.close": "Close",
+    "title.game": "Game",
+    "errors.registryLoad": "Couldn't load <code>games/registry.json</code>. Are you serving over HTTP? Try <code>python -m http.server</code>.",
+    "stats.games": "games",
+    "filters.all": "All",
+    "card.tech.phaser": "Phaser",
+    "card.tech.three": "Three.js",
+    "card.tech.html": "HTML5",
+    "card.aria.play": "Play {name}",
+  },
+  hi: {
+    "brand.name": "गेम्स हब",
+    "hero.titleLine1": "140+ गेम्स।",
+    "hero.titleLine2": "एक रिपो। बिना किसी इंस्टॉलेशन के।",
+    "hero.subtitle": "ब्राउज़र-आधारित HTML5 गेम्स का बढ़ता कलेक्शन — Phaser, Three.js और vanilla JS से बना। किसी भी कार्ड पर क्लिक करें और तुरंत खेलें।",
+    "cta.playRandom": "रैंडम खेलें",
+    "cta.browseAll": "सभी देखें",
+    "search.placeholder": "गेम खोजें — नाम, टैग, श्रेणी…",
+    "empty.noMatches": "इस खोज से कोई गेम नहीं मिला।",
+    "empty.clearFilters": "फिल्टर हटाएं",
+    "footer.builtBy": "निर्माता",
+    "footer.source": "सोर्स",
+    "footer.contribute": "योगदान दें",
+    "footer.licensed": "MIT लाइसेंस",
+    "footer.language": "भाषा:",
+    "footer.press": "दबाएं",
+    "footer.toSearch": "खोजने के लिए",
+    "footer.toClose": "बंद करने के लिए",
+    "footer.forRandom": "रैंडम के लिए",
+    "language.english": "अंग्रेज़ी",
+    "language.hindi": "हिंदी",
+    "modal.defaultTitle": "—",
+    "aria.toggleTheme": "थीम बदलें",
+    "aria.viewSourceGithub": "GitHub पर सोर्स देखें",
+    "aria.filterGames": "गेम फिल्टर करें",
+    "aria.categories": "श्रेणियां",
+    "aria.toggleFullscreen": "फुलस्क्रीन बदलें",
+    "aria.restartGame": "गेम रीस्टार्ट करें",
+    "aria.openInNewTab": "नए टैब में खोलें",
+    "aria.close": "बंद करें",
+    "title.fullscreen": "फुलस्क्रीन",
+    "title.restart": "रीस्टार्ट",
+    "title.openInNewTab": "नए टैब में खोलें",
+    "title.close": "बंद करें",
+    "title.game": "गेम",
+    "errors.registryLoad": "<code>games/registry.json</code> लोड नहीं हो सका। क्या आप HTTP सर्वर चला रहे हैं? <code>python -m http.server</code> आज़माएं।",
+    "stats.games": "गेम्स",
+    "filters.all": "सभी",
+    "card.tech.phaser": "Phaser",
+    "card.tech.three": "Three.js",
+    "card.tech.html": "HTML5",
+    "card.aria.play": "{name} खेलें",
+  },
+};
 
 // per-category emoji used as the visual on cards
 const CATEGORY_EMOJI_FALLBACK = {
@@ -104,6 +194,7 @@ const els = {
   modalOpen: document.getElementById("modal-open"),
   modalReload: document.getElementById("modal-reload"),
   modalFs: document.getElementById("modal-fullscreen"),
+  languageSelect: document.getElementById("language-select"),
 };
 
 const state = {
@@ -111,13 +202,18 @@ const state = {
   categories: [],
   q: "",
   category: "all",
+  locale: DEFAULT_LOCALE,
 };
 
 // ---------- Init ----------
 init();
 
 async function init() {
+  state.locale = loadLanguage();
+  document.documentElement.lang = state.locale;
   loadTheme();
+  applyI18n();
+  if (els.languageSelect) els.languageSelect.value = state.locale;
   attachUiEvents();
 
   try {
@@ -129,7 +225,7 @@ async function init() {
   } catch (err) {
     console.error("Failed to load registry:", err);
     els.grid.innerHTML = `<p style="grid-column:1/-1;color:var(--text-dim);text-align:center;padding:40px">
-      Couldn't load <code>games/registry.json</code>. Are you serving over HTTP? Try <code>python -m http.server</code>.</p>`;
+      ${t("errors.registryLoad")}</p>`;
     return;
   }
 
@@ -154,6 +250,12 @@ function setTheme(t) {
 
 // ---------- UI events ----------
 function attachUiEvents() {
+  if (els.languageSelect) {
+    els.languageSelect.addEventListener("change", (e) => {
+      setLanguage(e.target.value);
+      window.location.reload();
+    });
+  }
   els.themeToggle.addEventListener("click", () => {
     setTheme(document.documentElement.dataset.theme === "light" ? "dark" : "light");
   });
@@ -211,7 +313,7 @@ function renderStats() {
     .sort((a, b) => b.n - a.n)
     .slice(0, 4);
   els.stats.innerHTML = `
-    <span class="stat"><span class="stat__num">${state.games.length}</span> games</span>
+    <span class="stat"><span class="stat__num">${state.games.length}</span> ${t("stats.games")}</span>
     ${top.map(({ c, n }) => `<span class="stat"><span class="stat__num">${n}</span> ${c.emoji} ${c.label}</span>`).join("")}
   `;
 }
@@ -221,7 +323,7 @@ function renderFilters() {
   const counts = {};
   for (const g of state.games) counts[g.category] = (counts[g.category] || 0) + 1;
   const all = `<button class="chip" type="button" data-cat="all" aria-pressed="${state.category === "all"}">
-    All <span class="chip__count">${state.games.length}</span>
+    ${t("filters.all")} <span class="chip__count">${state.games.length}</span>
   </button>`;
   const cats = state.categories
     .map((c) => `<button class="chip" type="button" data-cat="${c.id}" aria-pressed="${state.category === c.id}">
@@ -265,10 +367,10 @@ function renderCard(g) {
   const emoji = GAME_EMOJI[g.slug] || CATEGORY_EMOJI_FALLBACK[g.category] || "🎮";
   const grad = CATEGORY_GRAD[g.category] || ["#444", "#222"];
   const cat = state.categories.find((c) => c.id === g.category);
-  const techLabel = g.tech === "phaser" ? "Phaser" : g.tech === "three" ? "Three.js" : "HTML5";
+  const techLabel = g.tech === "phaser" ? t("card.tech.phaser") : g.tech === "three" ? t("card.tech.three") : t("card.tech.html");
   return `
     <button class="card" data-slug="${g.slug}" data-category="${g.category}"
-      style="--card-c1:${grad[0]};--card-c2:${grad[1]}" aria-label="Play ${escapeAttr(g.name)}">
+      style="--card-c1:${grad[0]};--card-c2:${grad[1]}" aria-label="${escapeAttr(t("card.aria.play", { name: g.name }))}">
       <div class="card__art">
         <span class="card__emoji" aria-hidden="true">${emoji}</span>
         <span class="card__play" aria-hidden="true">▶</span>
@@ -366,3 +468,39 @@ function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 }
 function escapeAttr(s) { return escapeHtml(s); }
+
+function loadLanguage() {
+  const saved = localStorage.getItem(LOCALE_STORAGE_KEY);
+  if (saved && I18N[saved]) return saved;
+  return DEFAULT_LOCALE;
+}
+
+function setLanguage(locale) {
+  state.locale = I18N[locale] ? locale : DEFAULT_LOCALE;
+  localStorage.setItem(LOCALE_STORAGE_KEY, state.locale);
+  document.documentElement.lang = state.locale;
+}
+
+function t(key, vars = {}) {
+  const dict = I18N[state.locale] || I18N[DEFAULT_LOCALE];
+  let text = dict[key] ?? key;
+  for (const [name, value] of Object.entries(vars)) {
+    text = text.replaceAll(`{${name}}`, String(value));
+  }
+  return text;
+}
+
+function applyI18n(root = document) {
+  root.querySelectorAll("[data-i18n]").forEach((el) => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  root.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    el.setAttribute("placeholder", t(el.dataset.i18nPlaceholder));
+  });
+  root.querySelectorAll("[data-i18n-aria-label]").forEach((el) => {
+    el.setAttribute("aria-label", t(el.dataset.i18nAriaLabel));
+  });
+  root.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    el.setAttribute("title", t(el.dataset.i18nTitle));
+  });
+}

--- a/site/app.js
+++ b/site/app.js
@@ -1,9 +1,4 @@
-/* =========================================================
-   Games Hub — landing page logic
-   - Loads games/registry.json
-   - Renders grid, search, category filters
-   - Modal iframe player with deep-link via URL hash
-   ========================================================= */
+
 
 const GH_REPO = "sausi-7/games";
 const DEFAULT_LOCALE = "en";


### PR DESCRIPTION
## Summary
Adds basic i18n support to the landing page with English (en) and Hindi (hi).

## Changes
- Introduced a simple translations object (en, hi)
- Replaced hardcoded UI text with translation keys
- Added language selector in footer
- Persisted selected language using localStorage
- Synced <html lang> with selected language

## Notes
Minimal implementation without affecting existing functionality.

Happy to make changes if needed!