### PR TITLE
feat: add keyboard shortcut help overlay (press ?)

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,21 @@
     </div>
   </div>
 
+  <!-- Keyboard shortcut overlay -->
+  <div id="shortcut-overlay" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" style="display:none;">
+    <div id="shortcut-backdrop"></div>
+    <div id="shortcut-box">
+      <h2>Keyboard Shortcuts</h2>
+      <ul>
+        <li><kbd>/</kbd> Search</li>
+        <li><kbd>R</kbd> Random game</li>
+        <li><kbd>Esc</kbd> Close</li>
+        <li><kbd>?</kbd> Show this panel</li>
+      </ul>
+      <button id="shortcut-close">Close</button>
+    </div>
+  </div>
+
   <script src="site/app.js" defer></script>
 </body>
-</html>
+</html>=

--- a/site/app.js
+++ b/site/app.js
@@ -189,13 +189,15 @@ function attachUiEvents() {
 
   // Keyboard
   document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && !els.modal.hidden) {
-      closeModal();
+    if (e.key === "Escape") {
+      if (!els.modal.hidden) { closeModal(); return; }
+      hideShortcuts();
       return;
     }
     if (e.target.matches("input, textarea")) return;
     if (e.key === "/") { e.preventDefault(); els.search.focus(); }
     else if (e.key.toLowerCase() === "r" && els.modal.hidden) playRandom();
+    else if (e.key === "?") showShortcuts();
   });
 
   // Hash changes
@@ -366,3 +368,17 @@ function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 }
 function escapeAttr(s) { return escapeHtml(s); }
+
+// ---------- KEYBOARD SHORTCUT OVERLAY ----------
+const shortcutOverlay = document.getElementById('shortcut-overlay');
+
+function showShortcuts() {
+  shortcutOverlay.style.display = 'flex';
+}
+
+function hideShortcuts() {
+  shortcutOverlay.style.display = 'none';
+}
+
+document.getElementById('shortcut-backdrop').addEventListener('click', hideShortcuts);
+document.getElementById('shortcut-close').addEventListener('click', hideShortcuts);

--- a/site/styles.css
+++ b/site/styles.css
@@ -625,3 +625,81 @@ kbd {
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }
 }
+/* ---------- KEYBOARD SHORTCUT OVERLAY ---------- */
+#shortcut-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#shortcut-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 23, 43, 0.45);
+  backdrop-filter: blur(6px);
+}
+
+[data-theme="dark"] #shortcut-backdrop {
+  background: rgba(5, 7, 12, 0.78);
+}
+
+#shortcut-box {
+  position: relative;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: 20px;
+  padding: 28px 32px;
+  min-width: 300px;
+  box-shadow: 0 30px 70px rgba(80, 70, 180, 0.35);
+  animation: pop 0.22s cubic-bezier(.2,.9,.3,1.2);
+}
+
+#shortcut-box h2 {
+  margin: 0 0 16px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+#shortcut-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#shortcut-box li {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 15px;
+  color: var(--text-dim);
+}
+
+#shortcut-box kbd {
+  min-width: 32px;
+  text-align: center;
+  font-size: 13px;
+  padding: 3px 8px;
+}
+
+#shortcut-close {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+
+#shortcut-close:hover {
+  background: var(--bg-card-hover);
+}


### PR DESCRIPTION
Closes #8

## What this PR does
- Press `?` to show a help overlay listing all keyboard shortcuts
- Press `Esc` or click outside to close the overlay
- Close button inside the panel also works
- Skips trigger when focus is inside an input field

## Changes
- `index.html` — added overlay HTML
- `site/styles.css` — added overlay styles
- `site/app.js` — added show/hide logic integrated with existing keyboard handler